### PR TITLE
[codex] add browser-backed ACM profile crawler and data notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,7 @@ CSV files are kept in `data/` and use Unix LF line endings.
 
 - `scripts/validate_google_scholar_profiles.py`: validates ACM Fellows Google Scholar profile links and caches fetched Scholar pages for reuse.
 - `scripts/cache_acm_fellow_profiles.py`: caches ACM Fellow profile pages and reports parsed profile fields for comparison with `data/acm_fellows.csv`.
+- `scripts/cache_acm_fellow_profiles_playwright.py`: browser-backed ACM profile crawler for pages that require a real browser session.
 
 See [README_FOR_AGENTS.md](README_FOR_AGENTS.md) for crawler/cache details intended for future coding agents.
+See [data_notes.md](data_notes.md) for current known data oddities.

--- a/README_FOR_AGENTS.md
+++ b/README_FOR_AGENTS.md
@@ -1,9 +1,10 @@
 # README For Agents
 
-This repository currently has two agent-oriented utility scripts under `scripts/`:
+This repository currently has three agent-oriented utility scripts under `scripts/`:
 
 ```text
 scripts/cache_acm_fellow_profiles.py
+scripts/cache_acm_fellow_profiles_playwright.py
 scripts/validate_google_scholar_profiles.py
 ```
 
@@ -11,7 +12,7 @@ Ignore the project `README.md` for these workflows. This file documents the loca
 
 ## Local Python Environment
 
-Use Python 3.10 or newer from the repository root. The active crawler/validator scripts only use the Python standard library, so no package install is required for the current workflow.
+Use Python 3.10 or newer from the repository root. The default crawler/validator scripts only use the Python standard library. The Playwright crawler is optional and requires Playwright plus a browser install.
 
 Recommended setup:
 
@@ -24,6 +25,13 @@ python -m py_compile scripts/cache_acm_fellow_profiles.py scripts/validate_googl
 After activation, run commands with `python ...` from the repo root. If you choose not to create a virtual environment, use `python3 ...` consistently.
 
 `requirements.txt` is retained for now but includes dependencies from older removed experiments. Do not install it just to run the scripts documented here.
+
+Optional Playwright setup:
+
+```bash
+python -m pip install playwright
+python -m playwright install chromium
+```
 
 ## Data Layout
 
@@ -38,7 +46,7 @@ data/turing_award_winners.csv
 `data/acm_fellows.csv` is the canonical ACM Fellows table. Its current columns are:
 
 ```text
-name,Year,Location,Citation,ACM Fellow Profile,DBLP profile,Google Scholar Profile
+name,year,location,citation,acm_fellow_profile,dblp_profile,google_scholar_profile
 ```
 
 The `name` field should be a clean person name. Do not include leading honorifics such as `Dr.`, `Prof.`, `Professor`, `Mr.`, `Dame`, or trailing credentials such as `PhD`, `Ph.D.`, `DPhil`, or `CCP`.
@@ -65,12 +73,12 @@ Use this page to discover new ACM Fellows before running profile-page enrichment
 It does not provide the full citation, DBLP profile, or Google Scholar profile. When adding directory-only rows to `data/acm_fellows.csv`, fill what is available:
 
 - `name`: convert `Last, Given` to clean `Given Last`;
-- `Year`: directory year;
-- `Location`: directory region, until the individual profile page provides a more specific location;
-- `ACM Fellow Profile`: directory profile URL;
-- leave `Citation`, `DBLP profile`, and `Google Scholar Profile` blank if unavailable.
+- `year`: directory year;
+- `location`: directory region, until the individual profile page provides a more specific location;
+- `acm_fellow_profile`: directory profile URL;
+- leave `citation`, `dblp_profile`, and `google_scholar_profile` blank if unavailable.
 
-Keep `data/acm_fellows.csv` sorted by `Year` descending, then `name` ascending. Most recent Fellows should appear first.
+Keep `data/acm_fellows.csv` sorted by `year` descending, then `name` ascending. Most recent Fellows should appear first.
 
 Direct `curl` requests to `awards.acm.org` may return a Cloudflare block page. If that happens, use a browser-capable fetch path or a text-rendered mirror for inspection, and keep any temporary scan reports under `.cache/`. The current local scan report path is:
 
@@ -80,7 +88,7 @@ Direct `curl` requests to `awards.acm.org` may return a Cloudflare block page. I
 
 ## ACM Fellow Profile Crawler
 
-`scripts/cache_acm_fellow_profiles.py` caches the `ACM Fellow Profile` URLs in the canonical ACM Fellows CSV:
+`scripts/cache_acm_fellow_profiles.py` caches the `acm_fellow_profile` URLs in the canonical ACM Fellows CSV:
 
 ```text
 data/acm_fellows.csv
@@ -89,7 +97,7 @@ data/acm_fellows.csv
 The script:
 
 - reads ACM Fellows rows from `data/acm_fellows.csv` by default;
-- extracts unique non-empty `ACM Fellow Profile` URLs;
+- extracts unique non-empty `acm_fellow_profile` URLs;
 - fetches each ACM profile page conservatively;
 - caches the complete fetched HTML page for reuse;
 - parses the page name, ACM Fellows award heading, location, year, and citation when available;
@@ -153,6 +161,7 @@ Other possible `status` values include:
 
 - `ok`: page fetched and the ACM Fellows award section was parsed.
 - `http_error`: ACM returned an HTTP error.
+- `blocked`: ACM returned a Cloudflare/interstitial-style page instead of profile content.
 - `url_error`: DNS/network/connection failure.
 - `timeout`: request timed out.
 - `invalid_url`: URL is not HTTP/HTTPS.
@@ -161,11 +170,57 @@ Other possible `status` values include:
 
 The report contains `review_candidates` for rows where the page did not parse cleanly, or parsed name/year/location/citation differs from the CSV. Treat these as review candidates, not automatic CSV fixes.
 
-When propagating ACM crawl results into `data/acm_fellows.csv`, use only entries whose `status` is `ok`, and do not overwrite existing CSV values with blank parsed fields. The crawled page is newer than the original CSV for `name`, `Year`, `Location`, and `Citation`, but parsed names must remain clean names as described above.
+When propagating ACM crawl results into `data/acm_fellows.csv`, use only entries whose `status` is `ok`, and do not overwrite existing CSV values with blank parsed fields. The crawled page is newer than the original CSV for `name`, `year`, `location`, and `citation`, but parsed names must remain clean names as described above.
+
+Current ACM profile crawl notes:
+
+- The 2026-04-29 browser/CDP retry resolved all previously cached `blocked` pages.
+- The current report has 1,629 `ok` entries, 0 `blocked` entries, and 11 `http_error` entries.
+- The 11 `http_error` entries are ACM 404 pages. They are documented in `data_notes.md`.
+
+## ACM Fellow Playwright Crawler
+
+`scripts/cache_acm_fellow_profiles_playwright.py` is a browser-backed companion to `scripts/cache_acm_fellow_profiles.py`. Use it when direct Python requests return `blocked` pages but the public ACM profile page works in a browser.
+
+It uses the same input CSV, cache, report, parser, and report builder:
+
+```text
+data/acm_fellows.csv
+.cache/acm-fellow-profile-cache.json
+.cache/acm-fellow-profile-report.json
+```
+
+Basic commands:
+
+```bash
+python scripts/cache_acm_fellow_profiles_playwright.py --limit-new 2
+python scripts/cache_acm_fellow_profiles_playwright.py --retry-status blocked --limit-new 2
+python scripts/cache_acm_fellow_profiles_playwright.py --headed --retry-status blocked --limit-new 2
+python scripts/cache_acm_fellow_profiles_playwright.py --headed --channel chrome --retry-status blocked --limit-new 2
+python scripts/cache_acm_fellow_profiles_playwright.py --headed --channel chrome --pause-before-read --retry-status blocked --limit-new 1
+python scripts/cache_acm_fellow_profiles_playwright.py --cdp-url http://127.0.0.1:9222 --retry-status blocked --limit-new 2
+python scripts/cache_acm_fellow_profiles_playwright.py --cdp-url http://127.0.0.1:9222 --retry-status blocked --delay 4 --delay-jitter 2 --batch-size 25 --batch-size-jitter 5 --batch-pause 90 --batch-pause-jitter 30
+python scripts/cache_acm_fellow_profiles_playwright.py --cdp-url http://127.0.0.1:9222 --retry-status blocked --delay 4 --delay-jitter 2 --batch-size 25 --batch-size-jitter 5 --batch-pause 90 --batch-pause-jitter 30 --limit-batches 2
+```
+
+The script uses a persistent Chromium profile by default:
+
+```text
+.cache/playwright-acm-profile
+```
+
+Use `--headed` when ACM requires interactive browser state. If a manual challenge or cookie prompt appears, use `--pause-before-read`, complete the challenge in the opened browser window, then press Enter in the terminal so the script caches the final page HTML. Subsequent runs reuse the same local profile. `--channel chrome` uses an installed Chrome browser instead of the bundled Playwright Chromium when available. Keep the profile under `.cache/` and do not commit it.
+
+If ACM works in a manually launched Chrome profile, connect to it over CDP:
+
+```bash
+open -na "Google Chrome" --args --remote-debugging-port=9222 --user-data-dir="$PWD/.cache/chrome-acm-cdp"
+python scripts/cache_acm_fellow_profiles_playwright.py --cdp-url http://127.0.0.1:9222 --retry-status blocked --limit-new 2
+```
 
 ## Google Scholar Validator
 
-`scripts/validate_google_scholar_profiles.py` validates the `Google Scholar Profile` URLs in the canonical ACM Fellows CSV:
+`scripts/validate_google_scholar_profiles.py` validates the `google_scholar_profile` URLs in the canonical ACM Fellows CSV:
 
 ```text
 data/acm_fellows.csv
@@ -174,7 +229,7 @@ data/acm_fellows.csv
 The script:
 
 - reads ACM Fellows rows from `data/acm_fellows.csv` by default;
-- extracts unique non-empty `Google Scholar Profile` URLs;
+- extracts unique non-empty `google_scholar_profile` URLs;
 - fetches each Scholar profile page conservatively;
 - caches the complete fetched HTML page for reuse;
 - extracts the Scholar page title;
@@ -316,9 +371,13 @@ Google Scholar default behavior is therefore:
 The ACM Fellow profile crawler uses lighter defaults:
 
 - `--delay` defaults to `2.0` seconds between uncached requests.
+- `--delay-jitter` defaults to `0.0`; when set, the actual sleep is randomized by plus/minus that many seconds and clamped at zero.
 - `--batch-size` defaults to `50` uncached requests.
+- `--batch-size-jitter` defaults to `0`; when set, each batch target is randomized by plus/minus that many requests and clamped to at least 1.
 - `--batch-pause` defaults to `60.0` seconds after each batch.
+- `--batch-pause-jitter` defaults to `0.0`; when set, the actual cooldown is randomized by plus/minus that many seconds and clamped at zero.
 - `--limit-new N` caps uncached requests for one run.
+- `--limit-batches N` caps completed batches for one run.
 
 If Google block markers appear while running the Scholar validator, stop the run and resume later without `--refresh`.
 

--- a/data/acm_fellows.csv
+++ b/data/acm_fellows.csv
@@ -1,4 +1,4 @@
-name,Year,Location,Citation,ACM Fellow Profile,DBLP profile,Google Scholar Profile
+name,year,location,citation,acm_fellow_profile,dblp_profile,google_scholar_profile
 Adam Wierman,2025,North America,,https://awards.acm.org/award-recipients/wierman_3144364,,
 Aggelos Kiayias,2025,Europe,,https://awards.acm.org/award-recipients/kiayias_5240130,,
 Alessandro Orso,2025,North America,,https://awards.acm.org/award-recipients/orso_4953717,,

--- a/data_notes.md
+++ b/data_notes.md
@@ -1,0 +1,64 @@
+# Data Notes
+
+## ACM Fellow profile crawl oddities
+
+As of the 2026-04-29 ACM Fellow profile crawl, `data/acm_fellows.csv` contains
+1,640 ACM Fellow profile URLs. The local cache/report live under `.cache/` and
+are intentionally not committed.
+
+Current cached profile status counts:
+
+```text
+Status       Count  Meaning
+----------  -----  ---------------------------------------------
+ok           1629  Profile page fetched and parsed successfully.
+blocked         0  No blocked/interstitial pages remain.
+http_error     11  ACM returned real 404 pages.
+missing         0  No missing ACM profile URLs.
+```
+
+Total profiles: 1,640. Cached profiles: 1,640. Review candidates: 215. The
+current report was generated at `2026-04-29T01:45:49Z`.
+
+The following people appear in `data/acm_fellows.csv`, but their individual ACM
+profile URLs currently return ACM 404 pages with page name
+`404 - Your Page Could Not Be Found`:
+
+| Name | ACM Fellow profile URL | Status |
+| --- | --- | --- |
+| John D Gannon | https://awards.acm.org/award-recipients/gannon_1259480 | 404 |
+| J D Couger | https://awards.acm.org/award-recipients/couger_1081272 | 404 |
+| Raymond Reiter | https://awards.acm.org/award-recipients/reiter_1131614 | 404 |
+| Larry Stockmeyer | https://awards.acm.org/award-recipients/stockmeyer_1438050 | 404 |
+| Chris S Wallace | https://awards.acm.org/award-recipients/wallace_1058015 | 404 |
+| Harold J Highland | https://awards.acm.org/award-recipients/highland_1042530 | 404 |
+| Bob O Evans | https://awards.acm.org/award-recipients/evans_1002203 | 404 |
+| David John Wheeler | https://awards.acm.org/award-recipients/wheeler_1002054 | 404 |
+| J Presper Eckert | https://awards.acm.org/award-recipients/eckert_4037602 | 404 |
+| Peter Elias | https://awards.acm.org/award-recipients/elias_1192715 | 404 |
+| Roger M Needham | https://awards.acm.org/award-recipients/needham_1674183 | 404 |
+
+No replacement URLs have been confirmed for these entries. Treat the ACM
+directory/profile URL as the current CSV value unless ACM fixes or replaces the
+individual profile page.
+
+## ACM crawling notes
+
+Direct `urllib` requests and fresh Playwright browser profiles can be blocked by
+ACM/Cloudflare. The working approach is to use the Playwright crawler against a
+user-launched Chrome instance with remote debugging enabled:
+
+```sh
+open -na "Google Chrome" --args --remote-debugging-port=9222 --user-data-dir="$PWD/.cache/chrome-acm-cdp"
+python scripts/cache_acm_fellow_profiles_playwright.py --cdp-url http://127.0.0.1:9222 --retry-status blocked
+```
+
+The crawler is idempotent and cache-backed. Use `--retry-status blocked` to
+refresh blocked cache entries, and use `--refresh` only when intentionally
+recrawling already-successful pages.
+
+The successful retry used randomized pacing, for example:
+
+```sh
+python scripts/cache_acm_fellow_profiles_playwright.py --cdp-url http://127.0.0.1:9222 --retry-status blocked --delay 4 --delay-jitter 2 --batch-size 25 --batch-size-jitter 5 --batch-pause 90 --batch-pause-jitter 30
+```

--- a/scripts/cache_acm_fellow_profiles.py
+++ b/scripts/cache_acm_fellow_profiles.py
@@ -166,11 +166,19 @@ def row_name(row: dict[str, str]) -> str:
     return str(row.get("name") or "").strip()
 
 
+def row_value(row: dict[str, str], *keys: str) -> str:
+    for key in keys:
+        value = row.get(key)
+        if value:
+            return str(value).strip()
+    return ""
+
+
 def unique_profiles(rows: list[dict[str, str]]) -> list[AcmProfile]:
     seen: set[str] = set()
     profiles: list[AcmProfile] = []
     for row_number, row in enumerate(rows, start=1):
-        url = (row.get("ACM Fellow Profile") or "").strip()
+        url = row_value(row, "ACM Fellow Profile", "acm_fellow_profile")
         if not url or url in seen:
             continue
         seen.add(url)
@@ -179,9 +187,9 @@ def unique_profiles(rows: list[dict[str, str]]) -> list[AcmProfile]:
                 index=row_number,
                 name=row_name(row),
                 url=url,
-                year=str(row.get("Year") or "").strip(),
-                location=str(row.get("Location") or "").strip(),
-                citation=str(row.get("Citation") or "").strip(),
+                year=row_value(row, "Year", "year"),
+                location=row_value(row, "Location", "location"),
+                citation=row_value(row, "Citation", "citation"),
             )
         )
     return profiles
@@ -265,6 +273,21 @@ def decode_body(body: bytes, headers: Any) -> str:
     return body.decode(charset or "utf-8", errors="replace")
 
 
+def looks_blocked(body: str) -> bool:
+    text = body.lower()
+    markers = [
+        "sorry, you have been blocked",
+        "cf-browser-verification",
+        "cf-chl-",
+        "cloudflare ray id",
+        "enable_cookies",
+        "our systems have detected unusual traffic",
+    ]
+    if any(marker in text for marker in markers):
+        return True
+    return "cloudflareapps" in text and "awards-winners__citation" not in text
+
+
 def parse_profile_html(body: str) -> dict[str, str]:
     parser = AcmProfileParser()
     parser.feed(body)
@@ -301,16 +324,20 @@ def fetch_profile(url: str) -> dict[str, Any]:
             body = decode_body(response.read(), response.headers)
             status_code = response.status
     except urllib.error.HTTPError as error:
+        body = decode_body(error.read(), error.headers)
         return {
-            "status": "http_error",
+            "status": "blocked" if looks_blocked(body) else "http_error",
             "status_code": error.code,
-            "html": decode_body(error.read(), error.headers),
+            "html": body,
             "fetched_at": fetched_at,
         }
     except urllib.error.URLError as error:
         return {"status": "url_error", "error": str(error.reason), "html": "", "fetched_at": fetched_at}
     except TimeoutError:
         return {"status": "timeout", "html": "", "fetched_at": fetched_at}
+
+    if looks_blocked(body):
+        return {"status": "blocked", "status_code": status_code, "html": body, "fetched_at": fetched_at}
 
     parsed = parse_profile_html(body)
     if not parsed.get("page_name"):
@@ -346,6 +373,8 @@ def build_report(profiles: list[AcmProfile], cache: dict[str, Any]) -> dict[str,
             continue
 
         status = cached.get("status", "unknown")
+        if status == "http_error" and looks_blocked(str(cached.get("html") or "")):
+            status = "blocked"
         page_name = clean_person_name(str(cached.get("page_name") or ""))
         parsed_year = str(cached.get("year") or "").strip()
         parsed_location = str(cached.get("location") or "").strip()

--- a/scripts/cache_acm_fellow_profiles_playwright.py
+++ b/scripts/cache_acm_fellow_profiles_playwright.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Cache ACM Fellow profile pages with Playwright.
+
+This is a browser-backed companion to cache_acm_fellow_profiles.py. It writes to
+the same cache/report files, but fetches pages through Chromium so pages that
+need browser JavaScript can be handled without changing the parser/report path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from cache_acm_fellow_profiles import (
+    DEFAULT_CACHE,
+    DEFAULT_DATA,
+    DEFAULT_REPORT,
+    atomic_write_json,
+    build_report,
+    load_json,
+    load_rows,
+    looks_blocked,
+    parse_profile_html,
+    unique_profiles,
+)
+
+
+DEFAULT_USER_DATA_DIR = Path(__file__).resolve().parents[1] / ".cache" / "playwright-acm-profile"
+RETRY_STATUSES = {"blocked", "http_error", "missing", "no_fellow_award", "no_name", "timeout", "url_error"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data", type=Path, default=DEFAULT_DATA, help="Path to data/acm_fellows.csv.")
+    parser.add_argument("--cache", type=Path, default=DEFAULT_CACHE, help="JSON cache path.")
+    parser.add_argument("--report", type=Path, default=DEFAULT_REPORT, help="JSON report path.")
+    parser.add_argument("--user-data-dir", type=Path, default=DEFAULT_USER_DATA_DIR, help="Persistent browser profile path.")
+    parser.add_argument("--delay", type=float, default=2.0, help="Seconds to wait between uncached requests.")
+    parser.add_argument(
+        "--delay-jitter",
+        type=float,
+        default=0.0,
+        help="Random +/- seconds to add around --delay. Sleep is clamped at zero.",
+    )
+    parser.add_argument("--batch-size", type=int, default=50, help="Uncached requests per batch.")
+    parser.add_argument(
+        "--batch-size-jitter",
+        type=int,
+        default=0,
+        help="Random +/- requests to add around --batch-size for each batch. Batch size is clamped to at least 1.",
+    )
+    parser.add_argument("--batch-pause", type=float, default=60.0, help="Seconds to pause after each batch.")
+    parser.add_argument(
+        "--batch-pause-jitter",
+        type=float,
+        default=0.0,
+        help="Random +/- seconds to add around --batch-pause. Sleep is clamped at zero.",
+    )
+    parser.add_argument("--limit-batches", type=int, default=None, help="Optional cap on completed batches this run.")
+    parser.add_argument("--limit-new", type=int, default=None, help="Optional cap on fetched requests this run.")
+    parser.add_argument("--refresh", action="store_true", help="Refetch URLs even when cached.")
+    parser.add_argument(
+        "--retry-status",
+        action="append",
+        choices=sorted(RETRY_STATUSES),
+        help="Refetch cached entries with this status. Can be passed multiple times.",
+    )
+    parser.add_argument("--headed", action="store_true", help="Run Chromium visibly.")
+    parser.add_argument("--channel", default=None, help="Optional browser channel, for example 'chrome'.")
+    parser.add_argument("--cdp-url", default=None, help="Connect to an existing browser over CDP, for example http://127.0.0.1:9222.")
+    parser.add_argument("--slow-mo", type=int, default=0, help="Playwright slow motion in milliseconds.")
+    parser.add_argument("--timeout", type=int, default=30000, help="Navigation timeout in milliseconds.")
+    parser.add_argument("--settle", type=float, default=1.0, help="Seconds to wait after navigation before reading HTML.")
+    parser.add_argument("--pause-before-read", action="store_true", help="Wait for Enter before reading page HTML.")
+    return parser.parse_args()
+
+
+def jittered_seconds(base: float, jitter: float) -> float:
+    if base <= 0:
+        return 0.0
+    if jitter <= 0:
+        return base
+    return max(0.0, base + random.uniform(-jitter, jitter))
+
+
+def jittered_batch_size(base: int, jitter: int) -> int:
+    if base <= 1:
+        return 1
+    if jitter <= 0:
+        return base
+    return max(1, base + random.randint(-jitter, jitter))
+
+
+def import_playwright() -> Any:
+    try:
+        from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+        from playwright.sync_api import sync_playwright
+    except ImportError as error:
+        raise SystemExit(
+            "Playwright is not installed. Install it with:\n"
+            "  python -m pip install playwright\n"
+            "  python -m playwright install chromium"
+        ) from error
+    return sync_playwright, PlaywrightTimeoutError
+
+
+def cached_status(cache: dict[str, Any], url: str) -> str | None:
+    cached = cache.get(url)
+    if not cached:
+        return None
+    status = str(cached.get("status") or "unknown")
+    if status == "http_error" and looks_blocked(str(cached.get("html") or "")):
+        return "blocked"
+    return status
+
+
+def should_fetch(url: str, cache: dict[str, Any], refresh: bool, retry_statuses: set[str]) -> bool:
+    if refresh:
+        return True
+    status = cached_status(cache, url)
+    if status is None:
+        return True
+    return status in retry_statuses
+
+
+def cache_entry_from_html(url: str, html: str, status_code: int | None) -> dict[str, Any]:
+    fetched_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    if looks_blocked(html):
+        return {"status": "blocked", "status_code": status_code, "html": html, "fetched_at": fetched_at}
+
+    parsed = parse_profile_html(html)
+    if not parsed.get("page_name"):
+        status = "no_name"
+    elif not parsed.get("award_heading"):
+        status = "no_fellow_award"
+    else:
+        status = "ok"
+
+    return {"status": status, "status_code": status_code, "html": html, "fetched_at": fetched_at, **parsed}
+
+
+def fetch_with_page(
+    page: Any,
+    url: str,
+    timeout: int,
+    settle: float,
+    pause_before_read: bool,
+    playwright_timeout_error: Any,
+) -> dict[str, Any]:
+    fetched_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    try:
+        response = page.goto(url, wait_until="domcontentloaded", timeout=timeout)
+        try:
+            page.wait_for_load_state("networkidle", timeout=min(timeout, 10000))
+        except playwright_timeout_error:
+            pass
+        if pause_before_read:
+            print("Complete any browser challenge, then press Enter here to cache the current page.", flush=True)
+            input()
+        if settle > 0:
+            time.sleep(settle)
+        html = page.content()
+    except playwright_timeout_error:
+        return {"status": "timeout", "html": "", "fetched_at": fetched_at}
+    except Exception as error:  # Playwright can raise browser-specific transport errors.
+        return {"status": "url_error", "error": str(error), "html": "", "fetched_at": fetched_at}
+
+    status_code = response.status if response is not None else None
+    entry = cache_entry_from_html(url, html, status_code)
+    if status_code is not None and status_code >= 400 and entry["status"] != "blocked":
+        entry["status"] = "http_error"
+    return entry
+
+
+def main() -> int:
+    args = parse_args()
+    sync_playwright, playwright_timeout_error = import_playwright()
+
+    rows = load_rows(args.data)
+    profiles = unique_profiles(rows)
+    cache: dict[str, Any] = load_json(args.cache, {})
+    retry_statuses = set(args.retry_status or [])
+
+    fetched = 0
+    batch_requests = 0
+    completed_batches = 0
+    batch_target = jittered_batch_size(args.batch_size, args.batch_size_jitter)
+
+    with sync_playwright() as playwright:
+        browser = None
+        if args.cdp_url:
+            browser = playwright.chromium.connect_over_cdp(args.cdp_url)
+            context = browser.contexts[0] if browser.contexts else browser.new_context(
+                viewport={"width": 1440, "height": 1000},
+                locale="en-US",
+            )
+        else:
+            args.user_data_dir.mkdir(parents=True, exist_ok=True)
+            context = playwright.chromium.launch_persistent_context(
+                str(args.user_data_dir),
+                channel=args.channel,
+                headless=not args.headed,
+                slow_mo=args.slow_mo,
+                viewport={"width": 1440, "height": 1000},
+                locale="en-US",
+            )
+        page = context.new_page()
+
+        try:
+            for position, profile in enumerate(profiles, start=1):
+                if not should_fetch(profile.url, cache, args.refresh, retry_statuses):
+                    continue
+
+                if args.limit_new is not None and fetched >= args.limit_new:
+                    break
+
+                if batch_requests >= batch_target:
+                    completed_batches += 1
+                    if args.limit_batches is not None and completed_batches >= args.limit_batches:
+                        break
+                    pause = jittered_seconds(args.batch_pause, args.batch_pause_jitter)
+                    print(f"Pausing {pause:.1f}s after {batch_requests} fetched requests.", flush=True)
+                    time.sleep(pause)
+                    batch_requests = 0
+                    batch_target = jittered_batch_size(args.batch_size, args.batch_size_jitter)
+
+                print(f"[{position}/{len(profiles)}] fetching {profile.name}: {profile.url}", flush=True)
+                cache[profile.url] = fetch_with_page(
+                    page,
+                    profile.url,
+                    timeout=args.timeout,
+                    settle=args.settle,
+                    pause_before_read=args.pause_before_read,
+                    playwright_timeout_error=playwright_timeout_error,
+                )
+                fetched += 1
+                batch_requests += 1
+
+                atomic_write_json(args.cache, cache)
+                atomic_write_json(args.report, build_report(profiles, cache))
+
+                delay = jittered_seconds(args.delay, args.delay_jitter)
+                if delay > 0:
+                    time.sleep(delay)
+        finally:
+            if args.cdp_url:
+                page.close()
+                if browser is not None:
+                    browser.close()
+            else:
+                context.close()
+
+    atomic_write_json(args.cache, cache)
+    report = build_report(profiles, cache)
+    atomic_write_json(args.report, report)
+    print(
+        f"Done. profiles={report['total_profiles']} cached={report['cached_profiles']} "
+        f"review_candidates={report['review_candidate_count']} report={args.report}",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_google_scholar_profiles.py
+++ b/scripts/validate_google_scholar_profiles.py
@@ -87,11 +87,19 @@ def row_name(row: dict[str, Any]) -> str:
     return str(row.get("name") or "").strip()
 
 
+def row_value(row: dict[str, Any], *keys: str) -> str:
+    for key in keys:
+        value = row.get(key)
+        if value:
+            return str(value).strip()
+    return ""
+
+
 def unique_profiles(rows: list[dict[str, Any]]) -> list[ScholarProfile]:
     seen: set[str] = set()
     profiles: list[ScholarProfile] = []
     for row_number, row in enumerate(rows, start=1):
-        url = (row.get("Google Scholar Profile") or "").strip()
+        url = row_value(row, "Google Scholar Profile", "google_scholar_profile")
         if not url or url in seen:
             continue
         seen.add(url)
@@ -100,7 +108,7 @@ def unique_profiles(rows: list[dict[str, Any]]) -> list[ScholarProfile]:
                 index=row_number,
                 name=row_name(row),
                 url=url,
-                acm_profile=str(row.get("ACM Fellow Profile") or "").strip(),
+                acm_profile=row_value(row, "ACM Fellow Profile", "acm_fellow_profile"),
             )
         )
     return profiles


### PR DESCRIPTION
## Summary

- add a browser-backed Playwright/CDP crawler for ACM Fellow profile pages
- update ACM profile crawling to detect blocked ACM/Cloudflare pages and support the normalized ACM Fellows CSV headers
- document the local cache, CDP workflow, randomized crawl pacing, and current ACM profile crawl status
- add data notes for the 11 ACM profile URLs that currently return ACM 404 pages

## Validation

- `python -m py_compile scripts/cache_acm_fellow_profiles.py scripts/cache_acm_fellow_profiles_playwright.py scripts/validate_google_scholar_profiles.py`
- `python scripts/cache_acm_fellow_profiles.py --limit-new 0`
- `git diff --cached --check`